### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/recipe_albedolandcover.yml
+++ b/.github/workflows/recipe_albedolandcover.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_anav13jclim.yml
+++ b/.github/workflows/recipe_anav13jclim.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_arctic_ocean.yml
+++ b/.github/workflows/recipe_arctic_ocean.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_autoassess_landsurface_permafrost.yml
+++ b/.github/workflows/recipe_autoassess_landsurface_permafrost.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_autoassess_landsurface_soilmoisture.yml
+++ b/.github/workflows/recipe_autoassess_landsurface_soilmoisture.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_autoassess_landsurface_surfrad.yml
+++ b/.github/workflows/recipe_autoassess_landsurface_surfrad.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_autoassess_stratosphere.yml
+++ b/.github/workflows/recipe_autoassess_stratosphere.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_bock20jgr_fig_1-4.yml
+++ b/.github/workflows/recipe_bock20jgr_fig_1-4.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_bock20jgr_fig_6-7.yml
+++ b/.github/workflows/recipe_bock20jgr_fig_6-7.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_bock20jgr_fig_8-10.yml
+++ b/.github/workflows/recipe_bock20jgr_fig_8-10.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_capacity_factor.yml
+++ b/.github/workflows/recipe_capacity_factor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_carvalhais14nat.yml
+++ b/.github/workflows/recipe_carvalhais14nat.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_check_obs.yml
+++ b/.github/workflows/recipe_check_obs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_climate_change_hotspot.yml
+++ b/.github/workflows/recipe_climate_change_hotspot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_climwip_brunner2019_med.yml
+++ b/.github/workflows/recipe_climwip_brunner2019_med.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_climwip_brunner20esd.yml
+++ b/.github/workflows/recipe_climwip_brunner20esd.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_climwip_test_basic.yml
+++ b/.github/workflows/recipe_climwip_test_basic.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_climwip_test_performance_sigma.yml
+++ b/.github/workflows/recipe_climwip_test_performance_sigma.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_clouds_bias.yml
+++ b/.github/workflows/recipe_clouds_bias.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_clouds_ipcc.yml
+++ b/.github/workflows/recipe_clouds_ipcc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_cmug_h2o.yml
+++ b/.github/workflows/recipe_cmug_h2o.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_collins13ipcc.yml
+++ b/.github/workflows/recipe_collins13ipcc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_combined_indices.yml
+++ b/.github/workflows/recipe_combined_indices.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_concatenate_exps.yml
+++ b/.github/workflows/recipe_concatenate_exps.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_consecdrydays.yml
+++ b/.github/workflows/recipe_consecdrydays.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_correlation.yml
+++ b/.github/workflows/recipe_correlation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_cox18nature.yml
+++ b/.github/workflows/recipe_cox18nature.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_cvdp.yml
+++ b/.github/workflows/recipe_cvdp.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_daily_era5.yml
+++ b/.github/workflows/recipe_daily_era5.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_deangelis15nat.yml
+++ b/.github/workflows/recipe_deangelis15nat.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_deangelis15nat_fig1_fast.yml
+++ b/.github/workflows/recipe_deangelis15nat_fig1_fast.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_decadal.yml
+++ b/.github/workflows/recipe_decadal.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_diurnal_temperature_index.yml
+++ b/.github/workflows/recipe_diurnal_temperature_index.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_eady_growth_rate.yml
+++ b/.github/workflows/recipe_eady_growth_rate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ecs.yml
+++ b/.github/workflows/recipe_ecs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ecs_constraints.yml
+++ b/.github/workflows/recipe_ecs_constraints.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ecs_scatter.yml
+++ b/.github/workflows/recipe_ecs_scatter.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ensclus.yml
+++ b/.github/workflows/recipe_ensclus.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_era5-land.yml
+++ b/.github/workflows/recipe_era5-land.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_esacci_lst.yml
+++ b/.github/workflows/recipe_esacci_lst.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_esacci_oc.yml
+++ b/.github/workflows/recipe_esacci_oc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_extract_shape.yml
+++ b/.github/workflows/recipe_extract_shape.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_extreme_events.yml
+++ b/.github/workflows/recipe_extreme_events.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_extreme_index.yml
+++ b/.github/workflows/recipe_extreme_index.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_eyring06jgr.yml
+++ b/.github/workflows/recipe_eyring06jgr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_eyring13jgr_12.yml
+++ b/.github/workflows/recipe_eyring13jgr_12.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figure_914.yml
+++ b/.github/workflows/recipe_flato13ipcc_figure_914.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figure_924.yml
+++ b/.github/workflows/recipe_flato13ipcc_figure_924.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figure_942.yml
+++ b/.github/workflows/recipe_flato13ipcc_figure_942.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figure_945a.yml
+++ b/.github/workflows/recipe_flato13ipcc_figure_945a.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figure_96.yml
+++ b/.github/workflows/recipe_flato13ipcc_figure_96.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figure_98.yml
+++ b/.github/workflows/recipe_flato13ipcc_figure_98.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figures_926_927.yml
+++ b/.github/workflows/recipe_flato13ipcc_figures_926_927.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figures_92_95.yml
+++ b/.github/workflows/recipe_flato13ipcc_figures_92_95.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figures_938_941_cmip3.yml
+++ b/.github/workflows/recipe_flato13ipcc_figures_938_941_cmip3.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_flato13ipcc_figures_938_941_cmip6.yml
+++ b/.github/workflows/recipe_flato13ipcc_figures_938_941_cmip6.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_galytska23jgr.yml
+++ b/.github/workflows/recipe_galytska23jgr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_gier2020bg.yml
+++ b/.github/workflows/recipe_gier2020bg.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_globwat.yml
+++ b/.github/workflows/recipe_globwat.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_heatwaves_coldwaves.yml
+++ b/.github/workflows/recipe_heatwaves_coldwaves.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_hydro_forcing.yml
+++ b/.github/workflows/recipe_hydro_forcing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_hyint.yml
+++ b/.github/workflows/recipe_hyint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_hyint_extreme_events.yml
+++ b/.github/workflows/recipe_hyint_extreme_events.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_hype.yml
+++ b/.github/workflows/recipe_hype.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_impact.yml
+++ b/.github/workflows/recipe_impact.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ipccwg1ar6ch3_atmosphere.yml
+++ b/.github/workflows/recipe_ipccwg1ar6ch3_atmosphere.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_19.yml
+++ b/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_19.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_42_a.yml
+++ b/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_42_a.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_42_b.yml
+++ b/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_42_b.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_43.yml
+++ b/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_43.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_9.yml
+++ b/.github/workflows/recipe_ipccwg1ar6ch3_fig_3_9.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_julia.yml
+++ b/.github/workflows/recipe_julia.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_kcs.yml
+++ b/.github/workflows/recipe_kcs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_landcover.yml
+++ b/.github/workflows/recipe_landcover.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer13jclim.yml
+++ b/.github/workflows/recipe_lauer13jclim.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig1_clim.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig1_clim.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig1_clim_amip.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig1_clim_amip.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig2_taylor.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig2_taylor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig2_taylor_amip.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig2_taylor_amip.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig3-4_zonal.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig3-4_zonal.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig5_lifrac.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig5_lifrac.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig6_interannual.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig6_interannual.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig7_seas.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig7_seas.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig8_dyn.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig8_dyn.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig9-11ab_scatter.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig9-11ab_scatter.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lauer22jclim_fig9-11c_pdf.yml
+++ b/.github/workflows/recipe_lauer22jclim_fig9-11c_pdf.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_li17natcc.yml
+++ b/.github/workflows/recipe_li17natcc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_lisflood.yml
+++ b/.github/workflows/recipe_lisflood.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_marrmot.yml
+++ b/.github/workflows/recipe_marrmot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_martin18grl.yml
+++ b/.github/workflows/recipe_martin18grl.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_meehl20sciadv.yml
+++ b/.github/workflows/recipe_meehl20sciadv.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_miles_block.yml
+++ b/.github/workflows/recipe_miles_block.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_miles_eof.yml
+++ b/.github/workflows/recipe_miles_eof.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_miles_regimes.yml
+++ b/.github/workflows/recipe_miles_regimes.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_modes_of_variability.yml
+++ b/.github/workflows/recipe_modes_of_variability.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_monitor.yml
+++ b/.github/workflows/recipe_monitor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_monitor_with_refs.yml
+++ b/.github/workflows/recipe_monitor_with_refs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_mpqb_xch4.yml
+++ b/.github/workflows/recipe_mpqb_xch4.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_multimodel_products.yml
+++ b/.github/workflows/recipe_multimodel_products.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_my_personal_diagnostic.yml
+++ b/.github/workflows/recipe_my_personal_diagnostic.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ncl.yml
+++ b/.github/workflows/recipe_ncl.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_Landschuetzer2016.yml
+++ b/.github/workflows/recipe_ocean_Landschuetzer2016.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_amoc.yml
+++ b/.github/workflows/recipe_ocean_amoc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_bgc.yml
+++ b/.github/workflows/recipe_ocean_bgc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_example.yml
+++ b/.github/workflows/recipe_ocean_example.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_ice_extent.yml
+++ b/.github/workflows/recipe_ocean_ice_extent.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_multimap.yml
+++ b/.github/workflows/recipe_ocean_multimap.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_quadmap.yml
+++ b/.github/workflows/recipe_ocean_quadmap.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_ocean_scalar_fields.yml
+++ b/.github/workflows/recipe_ocean_scalar_fields.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_pcrglobwb.yml
+++ b/.github/workflows/recipe_pcrglobwb.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_perfmetrics_CMIP5.yml
+++ b/.github/workflows/recipe_perfmetrics_CMIP5.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_perfmetrics_CMIP5_4cds.yml
+++ b/.github/workflows/recipe_perfmetrics_CMIP5_4cds.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_perfmetrics_land_CMIP5.yml
+++ b/.github/workflows/recipe_perfmetrics_land_CMIP5.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_preprocessor_derive_test.yml
+++ b/.github/workflows/recipe_preprocessor_derive_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_preprocessor_test.yml
+++ b/.github/workflows/recipe_preprocessor_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_psyplot.yml
+++ b/.github/workflows/recipe_psyplot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_pv_capacity_factor.yml
+++ b/.github/workflows/recipe_pv_capacity_factor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_python.yml
+++ b/.github/workflows/recipe_python.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_python_for_CI.yml
+++ b/.github/workflows/recipe_python_for_CI.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_quantilebias.yml
+++ b/.github/workflows/recipe_quantilebias.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_r.yml
+++ b/.github/workflows/recipe_r.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_radiation_budget.yml
+++ b/.github/workflows/recipe_radiation_budget.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_rainfarm.yml
+++ b/.github/workflows/recipe_rainfarm.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_runoff_et.yml
+++ b/.github/workflows/recipe_runoff_et.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_russell18jgr.yml
+++ b/.github/workflows/recipe_russell18jgr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_schlund20esd.yml
+++ b/.github/workflows/recipe_schlund20esd.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_sea_surface_salinity.yml
+++ b/.github/workflows/recipe_sea_surface_salinity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_seaborn.yml
+++ b/.github/workflows/recipe_seaborn.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_seaice.yml
+++ b/.github/workflows/recipe_seaice.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_seaice_drift.yml
+++ b/.github/workflows/recipe_seaice_drift.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_seaice_feedback.yml
+++ b/.github/workflows/recipe_seaice_feedback.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_shapeselect.yml
+++ b/.github/workflows/recipe_shapeselect.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_smpi.yml
+++ b/.github/workflows/recipe_smpi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_smpi_4cds.yml
+++ b/.github/workflows/recipe_smpi_4cds.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_snowalbedo.yml
+++ b/.github/workflows/recipe_snowalbedo.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_spei.yml
+++ b/.github/workflows/recipe_spei.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_tcr.yml
+++ b/.github/workflows/recipe_tcr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_tebaldi21esd.yml
+++ b/.github/workflows/recipe_tebaldi21esd.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_thermodyn_diagtool.yml
+++ b/.github/workflows/recipe_thermodyn_diagtool.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_toymodel.yml
+++ b/.github/workflows/recipe_toymodel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_validation.yml
+++ b/.github/workflows/recipe_validation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_validation_CMIP6.yml
+++ b/.github/workflows/recipe_validation_CMIP6.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_variable_groups.yml
+++ b/.github/workflows/recipe_variable_groups.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_weigel21gmd_figures_13_16.yml
+++ b/.github/workflows/recipe_weigel21gmd_figures_13_16.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_wenzel14jgr.yml
+++ b/.github/workflows/recipe_wenzel14jgr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_wenzel16jclim.yml
+++ b/.github/workflows/recipe_wenzel16jclim.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_wenzel16nat.yml
+++ b/.github/workflows/recipe_wenzel16nat.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_wflow.yml
+++ b/.github/workflows/recipe_wflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_williams09climdyn_CREM.yml
+++ b/.github/workflows/recipe_williams09climdyn_CREM.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/recipe_zmnam.yml
+++ b/.github/workflows/recipe_zmnam.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest workflow run status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: latest-workflow-status
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
           target: log.txt
       - name: Upload log as artifact
         if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: output_log
           path: log.txt

--- a/.github/workflows/run_recipe.yml
+++ b/.github/workflows/run_recipe.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       #- name: Get latest workflow run status
-      #  uses: actions/github-script@v6
+      #  uses: actions/github-script@v9
       #  id: latest-workflow-status
       #  with:
       #    script: |
@@ -61,7 +61,7 @@ jobs:
       
       #- name: Upload log as artifact
       #  if: ${{ failure() || github.event.workflow_run.name == 'Run all recipes' || ( github.event.workflow_run.name == 'Run all failed' && steps.latest-workflow-status.outputs.result != 'success' ) || github.event_name == 'workflow_dispatch' }}
-      #  uses: actions/upload-artifact@v3
+      #  uses: actions/upload-artifact@v7
       #  with:
       #    name: output_log
       #    path: log.txt


### PR DESCRIPTION
Automated update of GitHub Actions to versions that run on the Node.js 24 runtime, replacing deprecated Node.js 16/20 versions.

All workflow YAML changes are limited to official GitHub Actions major version bumps (e.g. `actions/checkout`, `actions/setup-python`, etc.).